### PR TITLE
hide maplabel

### DIFF
--- a/resource/ui/spectator.res
+++ b/resource/ui/spectator.res
@@ -108,7 +108,7 @@
 		"tall"			"20"
 		"autoResize"	"0"
 		"pinCorner"		"0"
-		"visible"		"1"
+		"visible"		"0"
 		"enabled"		"1"
 		"labelText"		"map: cp_bridge"
 		"textAlignment"		"east"


### PR DESCRIPTION
The maplabel only works if you are coaching a player and have minmode disabled. Otherwise it shows "Map: cp_bridge"